### PR TITLE
.github: add workflow to bump tags to head of master

### DIFF
--- a/.github/bump-tags.yaml
+++ b/.github/bump-tags.yaml
@@ -1,0 +1,40 @@
+name: Bump Tags on Master
+
+on:
+  workflow_dispatch:
+
+jobs:
+  bump-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: Update all version tags
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
+          
+          # Update all version tags
+          git tag -fa v4 -m "Update v4 tag to latest commit on master"
+          git tag -fa v5 -m "Update v5 tag to latest commit on master"
+          git tag -fa v5.1.0 -m "Update v5.1.0 tag to latest commit on master"
+          git tag -fa v6 -m "Update v6 tag to latest commit on master"
+          git tag -fa v6.0.1 -m "Update v6.0.1 tag to latest commit on master"
+          git tag -fa v6.1.0 -m "Update v6.1.0 tag to latest commit on master"
+          
+          # Push all tags at once
+          git push origin v4 v5 v5.1.0 v6 v6.0.1 v6.1.0 --force
+
+      - name: Send Slack notification on success
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "text": "Updated all version tags (v4, v5, v5.1.0, v6, v6.0.1, v6.1.0) to the latest commit on master"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CACHE_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add GitHub Actions workflow to update version tags to the latest commit on master and notify via Slack.
> 
>   - **Workflow**:
>     - Adds `.github/bump-tags.yaml` to automate updating version tags to the latest commit on `master`.
>     - Triggered manually using `workflow_dispatch`.
>   - **Steps**:
>     - Checks out the `master` branch with full history.
>     - Updates tags `v4`, `v5`, `v5.1.0`, `v6`, `v6.0.1`, `v6.1.0` to the latest commit on `master`.
>     - Pushes updated tags forcefully to `origin`.
>     - Sends a Slack notification on successful tag update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fgolangci-lint-action&utm_source=github&utm_medium=referral)<sup> for d5356ba7b42609ed0a895ea58127a42baea2402e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->