### PR TITLE
docs: add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,3 +570,10 @@ Inside our action, we perform 3 steps:
    GitHub matches keys by prefix if we have no exact match for the primary cache.
 
 This scheme is basic and needs improvements. Pull requests and ideas are welcome.
+
+---
+
+## ⚠️ Archive Notice
+
+Blacksmith now supports transparent caching as explained in https://www.blacksmith.sh/blog/cache. To this effect it is recommended to switch to the upstream maintained versions of this action as you will continue to leverage our much faster caching without any code changes. This action will no longer receive dependency or security updates.
+


### PR DESCRIPTION
This repository is being archived. Adding notice to README before archiving.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an archive notice to the README, recommending migration to the upstream-maintained action leveraging Blacksmith transparent caching.
> 
> - **Documentation**:
>   - **`README.md`**:
>     - Add an Archive Notice section.
>     - Recommend switching to upstream-maintained versions due to Blacksmith transparent caching.
>     - Note that this action will no longer receive dependency or security updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8f6e889bb3df623d2e0b7e9e576c3efa6f1bf0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->