### PR TITLE
docs: add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,3 +570,10 @@ Inside our action, we perform 3 steps:
    GitHub matches keys by prefix if we have no exact match for the primary cache.
 
 This scheme is basic and needs improvements. Pull requests and ideas are welcome.
+
+---
+
+## ⚠️ Archive Notice
+
+Blacksmith now supports transparent caching as explained in https://www.blacksmith.sh/blog/cache. To this effect it is recommended to switch to the upstream maintained versions of this action as you will continue to leverage our much faster caching without any code changes. This action will no longer receive dependency or security updates.
+


### PR DESCRIPTION
This repository is being archived. Adding notice to README before archiving.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an archive notice to the README advising migration to the upstream-maintained action due to Blacksmith transparent caching.
> 
> - **Docs**:
>   - Add an *Archive Notice* to `README.md`.
>     - Notes Blacksmith transparent caching support and recommends switching to upstream-maintained action.
>     - States this action will no longer receive dependency or security updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ae543166b339273709d53cd1847c714273e6739. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->