### PR TITLE
docs: add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## ⚠️ Archive Notice
+
+Blacksmith now supports transparent caching as explained in https://www.blacksmith.sh/blog/cache. To this effect it is recommended to switch to the upstream maintained versions of this action as you will continue to leverage our much faster caching without any code changes. This action will no longer receive dependency or security updates.
+
+---
+
 # golangci-lint-action
 
 [![Build Status](https://github.com/golangci/golangci-lint-action/workflows/build-and-test/badge.svg)](https://github.com/golangci/golangci-lint-action/actions)


### PR DESCRIPTION
This repository is being archived. Adding notice to README before archiving.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an archive notice to the top of README recommending switching to the upstream-maintained action and noting no further updates.
> 
> - **Docs**:
>   - **`README.md`**: Add an archive notice at the top:
>     - Recommends switching to upstream-maintained action to leverage Blacksmith transparent caching (link provided).
>     - States this action will no longer receive dependency/security updates.
>     - Inserts a separator line after the notice.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75927653e3e66d13c0750ecf649085f8d5e22a11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->